### PR TITLE
Fixing contract tests

### DIFF
--- a/aws-ec2-capacityreservationfleet/inputs/inputs_1_create.json
+++ b/aws-ec2-capacityreservationfleet/inputs/inputs_1_create.json
@@ -6,7 +6,8 @@
       "InstancePlatform": "Linux/UNIX",
       "AvailabilityZone": "{{ExportedAvailabilityZone}}",
       "Weight": 1.1,
-      "Priority": 1
+      "Priority": 1,
+      "EbsOptimized": false
     }
   ],
   "Tenancy": "default",

--- a/aws-ec2-capacityreservationfleet/src/main/java/software/amazon/ec2/capacityreservationfleet/Translator.java
+++ b/aws-ec2-capacityreservationfleet/src/main/java/software/amazon/ec2/capacityreservationfleet/Translator.java
@@ -151,7 +151,6 @@ public class Translator {
               .instanceType(specification.instanceTypeAsString())
               .instancePlatform(specification.instancePlatformAsString())
               .availabilityZone(specification.availabilityZone())
-              .availabilityZoneId(specification.availabilityZoneId())
               .ebsOptimized(specification.ebsOptimized())
               .priority(specification.priority())
               .weight(specification.weight())


### PR DESCRIPTION
*Description of changes:*
Contract test requires given input needs(resource model) to be exactly equal to output(resource model).
In our case customer can provide AvailabilityZone or AvailabilityZoneId but not both meanwhile in output we were passing both values which is why our contract tests were failing.

With this change customer still can provide either AvailabilityZone or AvailabilityZoneId, but we do not add AvailabilityZoneId in out resource model.

Contract test local run
`cfn test --enforce-timeout 240`
```
resource/handler_create.py::contract_create_delete 
------------------------------------------------------------------------------------- live log call -------------------------------------------------------------------------------------
INFO     rpdk.core.contract.resource_client:resource_client.py:55 Caught LookupError when pruning properties for document {'properties': {'AllocationStrategy': 'prioritized', 'InstanceTypeSpecifications': [{'InstanceType': 't3.large', 'InstancePlatform': 'Linux/UNIX', 'AvailabilityZone': 'us-east-1a', 'Weight': 1.1, 'Priority': 1, 'EbsOptimized': False}], 'Tenancy': 'default', 'TotalTargetCapacity': 1, 'InstanceMatchCriteria': 'open'}} and path ('properties', 'CapacityReservationFleetId')
PASSED                                                                                                                                                                            [  6%]
resource/handler_create.py::contract_create_create 
------------------------------------------------------------------------------------ live log setup -------------------------------------------------------------------------------------
INFO     rpdk.core.contract.resource_client:resource_client.py:55 Caught LookupError when pruning properties for document {'properties': {'AllocationStrategy': 'prioritized', 'InstanceTypeSpecifications': [{'InstanceType': 't3.large', 'InstancePlatform': 'Linux/UNIX', 'AvailabilityZone': 'us-east-1a', 'Weight': 1.1, 'Priority': 1, 'EbsOptimized': False}], 'Tenancy': 'default', 'TotalTargetCapacity': 1, 'InstanceMatchCriteria': 'open'}} and path ('properties', 'CapacityReservationFleetId')
SKIPPED (No writable identifiers. Skipping test.)                                                                                                                                 [ 13%]
resource/handler_create.py::contract_create_read 
------------------------------------------------------------------------------------- live log call -------------------------------------------------------------------------------------
INFO     rpdk.core.contract.resource_client:resource_client.py:55 Caught LookupError when pruning properties for document {'properties': {'AllocationStrategy': 'prioritized', 'InstanceTypeSpecifications': [{'InstanceType': 't3.large', 'InstancePlatform': 'Linux/UNIX', 'AvailabilityZone': 'us-east-1a', 'Weight': 1.1, 'Priority': 1, 'EbsOptimized': False}], 'Tenancy': 'default', 'TotalTargetCapacity': 1, 'InstanceMatchCriteria': 'open'}} and path ('properties', 'CapacityReservationFleetId')
PASSED                                                                                                                                                                            [ 20%]
resource/handler_create.py::contract_create_list PASSED                                                                                                                           [ 26%]
resource/handler_create.py::contract_create_taggable SKIPPED (Resource does not contain tagging metadata. Skipping test.)                                                         [ 33%]
resource/handler_delete.py::contract_delete_read 
------------------------------------------------------------------------------------ live log setup -------------------------------------------------------------------------------------
INFO     rpdk.core.contract.resource_client:resource_client.py:55 Caught LookupError when pruning properties for document {'properties': {'AllocationStrategy': 'prioritized', 'InstanceTypeSpecifications': [{'InstanceType': 't3.large', 'InstancePlatform': 'Linux/UNIX', 'AvailabilityZone': 'us-east-1a', 'Weight': 1.1, 'Priority': 1, 'EbsOptimized': False}], 'Tenancy': 'default', 'TotalTargetCapacity': 1, 'InstanceMatchCriteria': 'open'}} and path ('properties', 'CapacityReservationFleetId')
PASSED                                                                                                                                                                            [ 40%]
resource/handler_delete.py::contract_delete_list PASSED                                                                                                                           [ 46%]
resource/handler_delete.py::contract_delete_update PASSED                                                                                                                         [ 53%]
resource/handler_delete.py::contract_delete_delete PASSED                                                                                                                         [ 60%]
resource/handler_delete.py::contract_delete_create SKIPPED (No writable identifiers. Skipping test.)                                                                              [ 66%]
resource/handler_misc.py::contract_check_asserts_work PASSED                                                                                                                      [ 73%]
resource/handler_update.py::contract_update_read 
------------------------------------------------------------------------------------ live log setup -------------------------------------------------------------------------------------
INFO     rpdk.core.contract.resource_client:resource_client.py:55 Caught LookupError when pruning properties for document {'properties': {'AllocationStrategy': 'prioritized', 'InstanceTypeSpecifications': [{'InstanceType': 't3.large', 'InstancePlatform': 'Linux/UNIX', 'AvailabilityZone': 'us-east-1a', 'Weight': 1.1, 'Priority': 1, 'EbsOptimized': False}], 'Tenancy': 'default', 'TotalTargetCapacity': 1, 'InstanceMatchCriteria': 'open'}} and path ('properties', 'CapacityReservationFleetId')
PASSED                                                                                                                                                                            [ 80%]
resource/handler_update.py::contract_update_list PASSED                                                                                                                           [ 86%]
resource/handler_update.py::contract_update_tag_updatable SKIPPED (Resource does not contain tagging metadata. Skipping test.)                                                    [ 93%]
resource/handler_update_invalid.py::contract_update_without_create PASSED                                                                                                         [100%]

=============================================================== 11 passed, 4 skipped, 6 deselected in 1297.21s (0:21:37) ================================================================
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
