### PR TITLE
Updating dependencies and returning end date in input format

### DIFF
--- a/aws-ec2-capacityreservationfleet/pom.xml
+++ b/aws-ec2-capacityreservationfleet/pom.xml
@@ -84,19 +84,19 @@
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>ec2</artifactId>
-            <version>2.17.119</version>
+            <version>2.20.20</version>
             <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>sdk-core</artifactId>
-            <version>2.17.119</version>
+            <version>2.20.20</version>
             <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>utils</artifactId>
-            <version>2.17.119</version>
+            <version>2.20.20</version>
             <scope>compile</scope>
         </dependency>
     </dependencies>

--- a/aws-ec2-capacityreservationfleet/src/main/java/software/amazon/ec2/capacityreservationfleet/Translator.java
+++ b/aws-ec2-capacityreservationfleet/src/main/java/software/amazon/ec2/capacityreservationfleet/Translator.java
@@ -168,7 +168,7 @@ public class Translator {
             .instanceTypeSpecifications(instanceTypeSpecifications)
             .tagSpecifications(CollectionUtils.isEmpty(tagSpecifications) ? null : tagSpecifications)
             .instanceMatchCriteria(crFleet.instanceMatchCriteria().toString())
-            .endDate(crFleet.endDate() != null ? String.valueOf(crFleet.endDate().getEpochSecond()) : null)
+            .endDate(crFleet.endDate() != null ? String.valueOf(crFleet.endDate()) : null)
             .build();
 
     final ResourceModel model = builder.build();


### PR DESCRIPTION
*Description of changes:*
Updating dependencies and returning end date in input format, previously we were converting the end date to epoch seconds before returning which was causing contract tests to fail. 

*Testing*
Built locally and ran contract tests.  

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
